### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,13 +10,6 @@ echo "--    PORT:              ${PORT}"
 
 echo ""
 
-if [ "${DEPLOYMENT_MODE}" = "PRODUCTION" ]; then
-  echo "Downloading latest database"
-  curl -o $DATABASE_PATH $DATABASE_URL
-else
-  echo "Using the existing database: ${DATABASE_PATH}"
-fi
-
-echo "Done Downloading latest database"
+echo "Using the existing database: ${DATABASE_PATH}"
 
 exec "$@"


### PR DESCRIPTION
`grid.json` is now stored directly in the repo and version controlled with git. It doesn't need to be downloaded from S3 in production.

This will change once we implement code to reference the Socrata API as the source of data.