### PR TITLE
Convert Timezone Properly

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -72,7 +72,7 @@ def to_local_string(timestamp):
 
     dt = datetime.utcfromtimestamp(timestamp)
 
-    dt.replace(tzinfo=tz)
+    dt.astimezone(tz)
 
     return dt.isoformat()[0:19]  # YYYY-MM-DDTHH:MM:SS
 
@@ -194,10 +194,14 @@ def get_trips(intersect_ids, flow_keys, **params):
 
     query = f"SELECT count(*) AS trip_count, {flow_key_end} WHERE {where_clause} GROUP BY {flow_key_end} LIMIT 10000000"
 
+    print(f"****** {query}")
+
     params = {"$query": query}
 
     res = requests.get(TRIPS_URL, params, timeout=90)
 
+    print(res.headers)
+    
     res.raise_for_status()
 
     return res.json()
@@ -305,4 +309,4 @@ async def ignore_404s(request, exception):
 # TODO: a good reason for removing it
 #
 # if __name__ == "__main__":
-    # app.run(host="0.0.0.0", port=8000, debug=True)
+#     app.run(host="0.0.0.0", port=8000, debug=True)

--- a/app/app.py
+++ b/app/app.py
@@ -194,14 +194,10 @@ def get_trips(intersect_ids, flow_keys, **params):
 
     query = f"SELECT count(*) AS trip_count, {flow_key_end} WHERE {where_clause} GROUP BY {flow_key_end} LIMIT 10000000"
 
-    print(f"****** {query}")
-
     params = {"$query": query}
 
     res = requests.get(TRIPS_URL, params, timeout=90)
 
-    print(res.headers)
-    
     res.raise_for_status()
 
     return res.json()

--- a/app/app.py
+++ b/app/app.py
@@ -239,7 +239,7 @@ tz = pytz.timezone("US/Central")
 
 with open(source, "r") as fin:
 
-    TRIPS_URL = "https://data.austintexas.gov/resource/pqaf-uftu.json"
+    TRIPS_URL = "https://data.austintexas.gov/resource/7d8e-dm7r.json"
 
     grid = json.loads(fin.read())
     idx = spatial_index(grid[feature_id] for feature_id in grid.keys())

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -29,8 +29,9 @@ def test_get_datetime():
     }
 
     request, response = app.test_client.get("/v1/trips", params=params)
-    
-    assert response.status == 200    
+
+    assert response.status == 200
+    assert len(response.json["features"]["features"]) > 0
 
 
 def test_get_query_geom_point():


### PR DESCRIPTION
When handling start/end times we were replacing the timezone offset rather than converting the timestamp to local time (which is required for the Socrata query). This fixes that and adds a test which checks to see if actual features are returned by the test query.