### PR TITLE
Update Socrata Endpoint

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -239,7 +239,7 @@ tz = pytz.timezone("US/Central")
 
 with open(source, "r") as fin:
 
-    TRIPS_URL = "https://data.austintexas.gov/resource/pqaf-uftu.json"
+    TRIPS_URL = "https://data.austintexas.gov/resource/7d8e-dm7r.json"
 
     grid = json.loads(fin.read())
     idx = spatial_index(grid[feature_id] for feature_id in grid.keys())


### PR DESCRIPTION
Internally, Socrata migrated our dataset to new infrastucture that is supposed to enhance v2.1 querying. This change also deprecated the previous '4x4' resource id of pqaf-uftu in favor of 7d8e-dm7r.

Although pqaf-uftu was supposedly still supported, it's no longer exposed via any user-interface, and we're experiencing some issues with the dataset locking up, so we'll go ahead an use 7d8e-dm7r going forward.